### PR TITLE
Process all queries with RM3 retriever

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,8 @@ from .retriever.RM3 import PyTerrierRM3Retriever
 if __name__ == "__main__":
     # Automatically gather all .yml files at the repo root (where main.py's parent is '..')
     root = Path(__file__).parent.parent
-    config_files = [str(f) for f in root.glob("*.yml")]
+    # Explicitly evaluate only the 2019 configuration
+    config_files = [str(root / "2019_dl_config.yml")]
 
     for config_file in config_files:
         # Load current config
@@ -54,7 +55,8 @@ if __name__ == "__main__":
 
         for label, pipeline in variants:
             run = {}
-            for qid, query in list(queries.items())[:2]:
+            # Evaluate over all queries
+            for qid, query in queries.items():
                 results = pipeline.run_query(qid, query, k=5)
                 run[qid] = results
 


### PR DESCRIPTION
## Summary
- restrict main to use only the 2019 config file
- run all queries instead of slicing to just a couple

## Testing
- `pytest -q tests/test_bm25_retriever.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6847d62bef40832ba40a3eb262fb720b