### PR TITLE
Fix RM3 apostrophe parsing

### DIFF
--- a/src/retriever/RM3.py
+++ b/src/retriever/RM3.py
@@ -3,6 +3,11 @@ import pyterrier as pt
 from ..schema import DocScore
 from ..domain.interfaces import Retriever
 
+
+def _escape_query(query: str) -> str:
+    """Escape apostrophes so Terrier's parser doesn't choke."""
+    return query.replace("'", "\\'")
+
 class PyTerrierRM3Retriever(Retriever):
     def __init__(self, fb_terms=3, fb_docs=2):
         # 0) Make sure PyTerrier is up and running
@@ -43,7 +48,8 @@ class PyTerrierRM3Retriever(Retriever):
         self.pipeline = bm25_initial >> rm3 >> bm25_final
 
     def search(self, query: str, k: int = 100) -> list[DocScore]:
-        qdf = pd.DataFrame([{"qid": "Q0", "query": query}])
+        safe_query = _escape_query(query)
+        qdf = pd.DataFrame([{"qid": "Q0", "query": safe_query}])
         res = self.pipeline.transform(qdf)
         topk = res.nlargest(k, "score")
         return [

--- a/tests/test_rm3_escape.py
+++ b/tests/test_rm3_escape.py
@@ -1,0 +1,12 @@
+import pytest
+
+from src.retriever.RM3 import _escape_query
+
+
+def test_escape_query_no_change():
+    assert _escape_query("hello world") == "hello world"
+
+
+def test_escape_query_with_apostrophe():
+    assert _escape_query("medicare's definition") == "medicare\\'s definition"
+


### PR DESCRIPTION
## Summary
- escape apostrophes before sending queries to PyTerrier
- test escaping helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*

------
https://chatgpt.com/codex/tasks/task_e_6847d9074944832b973a5f1a3a90df6d