### PR TITLE
Fix RM3 apostrophe parsing

### DIFF
--- a/tests/test_rm3_escape.py
+++ b/tests/test_rm3_escape.py
@@ -1,0 +1,12 @@
+import pytest
+
+from src.retriever.RM3 import _sanitize_query
+
+
+def test_sanitize_query_no_change():
+    assert _sanitize_query("hello world") == "hello world"
+
+
+def test_sanitize_query_with_apostrophe():
+    assert _sanitize_query("medicare's definition") == "medicares definition"
+


### PR DESCRIPTION
## Summary
- strip apostrophes from queries before passing them to PyTerrier
- update unit test for sanitising queries

## Testing
- `PYTHONPATH=. pytest tests/test_rm3_escape.py -q` *(fails: ModuleNotFoundError: No module named 'pyterrier')*


------
https://chatgpt.com/codex/tasks/task_e_6847d9074944832b973a5f1a3a90df6d