### PR TITLE
Remove unused import and fix newline

### DIFF
--- a/src/feedback/rocchio.py
+++ b/src/feedback/rocchio.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional
 import numpy as np
-from examples.clirmatrix_example import qrels
 
 from ..domain.interfaces import FeedbackService
 


### PR DESCRIPTION
## Summary
- remove unused `clirmatrix_example` import from Rocchio feedback
- ensure `rocchio.py` ends with a newline

## Testing
- `pip install numpy`
- `PYTHONPATH=$PYTHONPATH:$(pwd) pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*

------
https://chatgpt.com/codex/tasks/task_e_6848303eecb4832b801f743136134a7a