### PR TITLE
Fix Python 3.9 Type Hint compatibility

### DIFF
--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 from ..domain.interfaces import Retriever, FeedbackService, Evaluator
 
 from tqdm import tqdm
@@ -21,7 +21,7 @@ class Pipeline:
             feedback: FeedbackService,
             evaluator: Evaluator,
             embed_model,
-            doc_corpus: dict | None = None,
+            doc_corpus: Optional[Dict[str, str]] = None,
             batch_size: int = 64,
             use_fp16: bool = False,
     ):

--- a/src/retriever/embedding.py
+++ b/src/retriever/embedding.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Dict, List
+from typing import Dict, List, Optional
 import os
 import types
 
@@ -34,7 +34,7 @@ class EmbeddingRetriever(Retriever):
         self, 
         model_name: str, 
         corpus: Dict[str, str], 
-        index_path: str | None = None,
+        index_path: Optional[str] = None,
         batch_size: int = 64, 
         use_fp16: bool = False,
     ):

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from pydantic import BaseModel, Field
 import yaml
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 class Config(BaseModel):
     queries_path: str = Field(
@@ -44,9 +44,9 @@ class Config(BaseModel):
     cv_folds: int = Field(default=5, description="Number of folds for CV")
 
     # dev set paths
-    dev_queries_path: str | None = None
-    dev_top100_path: str | None = None
-    dev_qrels_path: str | None = None
+    dev_queries_path: Optional[str] = None
+    dev_top100_path: Optional[str] = None
+    dev_qrels_path: Optional[str] = None
 
     # RM3 search grid
     rm3_fb_docs: List[int] = Field(

--- a/src/utils/dependencies.py
+++ b/src/utils/dependencies.py
@@ -1,4 +1,5 @@
 from sentence_transformers import SentenceTransformer
+from typing import Optional
 
 from .config import Config
 from ..data_loader.loader import DataLoader
@@ -12,9 +13,9 @@ from ..pipeline.pipeline import Pipeline
 def build_pipeline(
     cfg: Config,
     *,
-    alpha: float | None = None,
-    beta: float | None = None,
-    rocchio_k: int | None = None,
+    alpha: Optional[float] = None,
+    beta: Optional[float] = None,
+    rocchio_k: Optional[int] = None,
 ) -> tuple[Pipeline, dict[str, str], dict[str, dict[str, int]]]:
     """Construct the main retrieval pipeline using the configuration."""
     dl = DataLoader(


### PR DESCRIPTION
## Summary
- replace `| None` type hints with `Optional[...]`
- update imports for `Optional`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483c207be4832b83b5defafc51dee6