### PR TITLE
Implement doc file existence check in DataLoader

### DIFF
--- a/src/data_loader/loader.py
+++ b/src/data_loader/loader.py
@@ -14,6 +14,9 @@ class DataLoader:
             docs_trec_gz: str,
             docs_json_path: str,     # ⬅️ Add path argument
     ):
+        if not (os.path.exists(docs_json_path) or os.path.exists(docs_trec_gz)):
+            raise FileNotFoundError(f"Document file not found: {docs_trec_gz}")
+
         # 1) Queries
         self.queries: Dict[str, str] = {}
         if queries_tsv.endswith('.gz'):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,34 @@
+import gzip
+import pytest
+import sys
+import types
+
+# Provide dummy ir_datasets module required by loader import
+sys.modules.setdefault("ir_datasets", types.ModuleType("ir_datasets"))
+
+from src.data_loader.loader import DataLoader
+
+
+def test_dataloader_missing_docs(tmp_path):
+    qfile = tmp_path / "queries.tsv"
+    qfile.write_text("q1\ttext\n")
+
+    topfile = tmp_path / "top100.gz"
+    with gzip.open(topfile, "wt", encoding="utf8") as f:
+        f.write("q1 Q0 D1 0 1.0\n")
+
+    qrelsfile = tmp_path / "qrels.txt"
+    qrelsfile.write_text("q1 0 D1 1\n")
+
+    missing_json = tmp_path / "docs.json"
+    missing_trec = tmp_path / "docs.trec.gz"
+
+    with pytest.raises(FileNotFoundError):
+        DataLoader(
+            str(qfile),
+            str(topfile),
+            str(qrelsfile),
+            str(missing_trec),
+            str(missing_json)
+        )
+


### PR DESCRIPTION
## Summary
- validate document file paths when creating `DataLoader`
- add unit test for the new exception

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484570d774832b8cc2eb5dac91f38e