### PR TITLE
Optimize CV by caching embeddings

### DIFF
--- a/src/retriever/RM3.py
+++ b/src/retriever/RM3.py
@@ -16,8 +16,10 @@ import string
 
 def _sanitize_query(query: str) -> str:
     """Remove all punctuation so Terrier’s parser won’t choke."""
-    # replace any punctuation char with space
-    sanitized = re.sub(f"[{re.escape(string.punctuation)}]", " ", query)
+    # remove apostrophes entirely, replace other punctuation with space
+    no_apost = query.replace("'", "")
+    punct_without_apost = string.punctuation.replace("'", "")
+    sanitized = re.sub(f"[{re.escape(punct_without_apost)}]", " ", no_apost)
     # collapse multiple spaces and trim
     return " ".join(sanitized.split())
 


### PR DESCRIPTION
## Summary
- cache query and document embeddings inside `Pipeline`
- disable progress bars and reuse cached vectors when running `run_query`
- precompute embeddings once and reuse the same pipeline in dense CV
- fix punctuation sanitization for RM3

## Testing
- `pip install rank_bm25 rich tqdm pyyaml`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aacb6a1a4832b8c9c7dede6e6641d